### PR TITLE
feat(testing): Add test framework

### DIFF
--- a/examples/simple/fn_test.go
+++ b/examples/simple/fn_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/crossplane/function-sdk-go/logging"
+	fntesting "github.com/mistermx/crossplane-function-server/testing"
+)
+
+var (
+	//go:embed testdata/composite.yaml
+	composite []byte
+
+	//go:embed testdata/input.yaml
+	input []byte
+
+	//go:embed testdata/expected-resources.yaml
+	expectedResources []byte
+
+	//go:embed testdata/expected-composite.yaml
+	expectedComposite []byte
+)
+
+func TestFunction(t *testing.T) {
+	fntesting.TestFunction(
+		t, &MyFunction{log: logging.NewNopLogger()},
+		fntesting.WithObservedCompositeYAML(composite),
+		fntesting.WithInputYAML(input),
+		fntesting.ExpectDesiredResourcesYAML(expectedResources),
+		fntesting.ExpectDesiredCompositeYAML(expectedComposite),
+	)
+}

--- a/examples/simple/testdata/composite.yaml
+++ b/examples/simple/testdata/composite.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: example.com/v1alpha1
+kind: Example
+metadata:
+  name: example
+spec: {}

--- a/examples/simple/testdata/expected-composite.yaml
+++ b/examples/simple/testdata/expected-composite.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: example.com/v1alpha1
+kind: Example
+metadata:
+  name: example
+  annotations:
+    fn-server.test/resource-name: clusterRole
+spec: {}

--- a/examples/simple/testdata/expected-resources.yaml
+++ b/examples/simple/testdata/expected-resources.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: composed
+  annotations:
+    fn-server.test/resource-name: clusterRole
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs:
+      - get
+      - watch
+      - list

--- a/examples/simple/testdata/input.yaml
+++ b/examples/simple/testdata/input.yaml
@@ -1,0 +1,3 @@
+input:
+  apiGroups: [""]
+  resources: ["pods"]

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.21
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/alecthomas/kong v0.8.1
+	github.com/crossplane/crossplane-runtime v1.14.2
 	github.com/crossplane/function-sdk-go v0.1.0
+	github.com/google/go-cmp v0.6.0
 	github.com/pkg/errors v0.9.1
 	google.golang.org/protobuf v1.31.0
 	k8s.io/apiextensions-apiserver v0.28.3
@@ -17,7 +19,6 @@ require (
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
-	github.com/crossplane/crossplane-runtime v1.14.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
@@ -32,7 +33,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/testing/helper_convert.go
+++ b/testing/helper_convert.go
@@ -1,0 +1,46 @@
+package testing
+
+import (
+	fnapi "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	"github.com/crossplane/function-sdk-go/resource"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func convertResultsToMap(r []*fnapi.Result) []map[string]interface{} {
+	if r == nil {
+		return nil
+	}
+	res := make([]map[string]interface{}, len(r))
+	for i, rr := range r {
+		if rr == nil {
+			continue
+		}
+		res[i] = map[string]interface{}{
+			"Message":  rr.Message,
+			"Severity": rr.Severity,
+		}
+	}
+	return res
+}
+
+func convertResourcesMapToUnstructured(r map[string]*fnapi.Resource) map[string]*unstructured.Unstructured {
+	if r == nil {
+		return nil
+	}
+	res := map[string]*unstructured.Unstructured{}
+	for k, v := range r {
+		res[k] = convertResourceToUnstructured(v)
+	}
+	return res
+}
+
+func convertResourceToUnstructured(r *fnapi.Resource) *unstructured.Unstructured {
+	if r == nil {
+		return nil
+	}
+	u := &unstructured.Unstructured{}
+	if err := resource.AsObject(r.Resource, u); err != nil {
+		panic(err)
+	}
+	return u
+}

--- a/testing/helper_parse.go
+++ b/testing/helper_parse.go
@@ -1,0 +1,72 @@
+package testing
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"unicode"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func mustUnstructuredFromYAML(rawYAML []byte) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal(rawYAML, u); err != nil {
+		panic(err.Error())
+	}
+	return u
+}
+
+func mustUnstructuredFromJSON(rawJSON []byte) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(rawJSON, u); err != nil {
+		panic(err.Error())
+	}
+	return u
+}
+
+func unmarshalObjectsYAML(rawYAML []byte) ([]*unstructured.Unstructured, error) {
+	buf := bytes.NewBuffer(rawYAML)
+	return unmarshalObjectsReader(buf)
+}
+
+func unmarshalObjectsReader(in io.Reader) ([]*unstructured.Unstructured, error) {
+	objects := []*unstructured.Unstructured{}
+	reader := yaml.NewYAMLReader(bufio.NewReader(in))
+	for {
+		data, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return objects, err
+		}
+		if len(data) == 0 {
+			continue
+		}
+		if isWhiteSpace(data) {
+			continue
+		}
+		o := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal(data, o); err != nil {
+			return nil, err
+		}
+		objects = append(objects, o)
+	}
+	return objects, nil
+}
+
+// isWhiteSpace determines whether the passed in bytes are all unicode white
+// space.
+func isWhiteSpace(bytes []byte) bool {
+	empty := true
+	for _, b := range bytes {
+		if !unicode.IsSpace(rune(b)) {
+			empty = false
+			break
+		}
+	}
+	return empty
+}

--- a/testing/helper_resource.go
+++ b/testing/helper_resource.go
@@ -1,0 +1,38 @@
+package testing
+
+import (
+	"encoding/json"
+
+	"github.com/crossplane/function-sdk-go/resource"
+	"google.golang.org/protobuf/types/known/structpb"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func mustObjectAsStruct(o runtime.Object) *structpb.Struct {
+	s, err := resource.AsStruct(o)
+	if err != nil {
+		panic(err.Error())
+	}
+	return s
+}
+
+func mustStructValue(in any) *structpb.Value {
+	val, err := structpb.NewValue(in)
+	if err != nil {
+		panic(err.Error())
+	}
+	return val
+}
+
+func mustObjectAsUnstructured(o runtime.Object) *unstructured.Unstructured {
+	raw, err := json.Marshal(o)
+	if err != nil {
+		panic(err.Error())
+	}
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(raw, u); err != nil {
+		panic(err.Error())
+	}
+	return u
+}

--- a/testing/opts_args.go
+++ b/testing/opts_args.go
@@ -1,0 +1,157 @@
+package testing
+
+import (
+	"encoding/json"
+
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	fnapi "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	evtv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// WithContextValue sets the expected context field to value.
+func WithContextValue(key string, value any) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		val := mustStructValue(value)
+		tc.args.context.Fields[key] = val
+	}
+}
+
+// WithContextValueYAML reads a value from a single YAML document and sets it
+// as value of the given context field.
+func WithContextValueYAML(key string, rawYAML []byte) TestFunctionOpt {
+	var val any
+	if err := yaml.Unmarshal(rawYAML, &val); err != nil {
+		panic(err.Error())
+	}
+	return WithContextValue(key, val)
+}
+
+// WithContextValueYAML reads a value from a JSON document and sets it
+// as value of the given context field.
+func WithContextValueJSON(key string, rawJSON []byte) TestFunctionOpt {
+	var val any
+	if err := json.Unmarshal(rawJSON, &val); err != nil {
+		panic(err.Error())
+	}
+	return WithContextValue(key, val)
+}
+
+// WithInput sets the input that is passed to the function run.
+// It accepts any value that can be marshaled to JSON.
+func WithInput(input any) TestFunctionOpt {
+	raw, err := json.Marshal(input)
+	if err != nil {
+		panic(err.Error())
+	}
+	return WithInputJSON(raw)
+}
+
+// WithInputYAML is the same as [WithInput] but accepts raw YAML.
+func WithInputYAML(inputYaml []byte) TestFunctionOpt {
+	rawJson, err := yaml.ToJSON(inputYaml)
+	if err != nil {
+		panic(err.Error())
+	}
+	return WithInputJSON(rawJson)
+}
+
+// WithInputJSON is the same as [WithInput] but accepts raw JSON.
+func WithInputJSON(inputJson []byte) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		tc.args.input = evtv1.JSON{Raw: inputJson}
+	}
+}
+
+// WithObservedResourceObject adds o to the observed state passed to the
+// function.
+func WithObservedResourceObject(name string, o runtime.Object) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		str := mustObjectAsStruct(o)
+		tc.args.observedResources[name] = &fnapi.Resource{
+			Resource: str,
+		}
+	}
+}
+
+// WithObservedResourceYAML reads an object from a single YAML document and adds
+// it to the observed state passed to the function.
+func WithObservedResourceYAML(name string, rawYaml []byte) TestFunctionOpt {
+	u := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal(rawYaml, u); err != nil {
+		panic(err.Error())
+	}
+	return WithObservedResourceObject(name, u)
+}
+
+// WithObservedResourceJSON reads an object from a single JSON document and adds
+// it to the observed state passed to the function.
+func WithObservedResourceJSON(name string, rawJSON []byte) TestFunctionOpt {
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(rawJSON, u); err != nil {
+		panic(err.Error())
+	}
+	return WithObservedResourceObject(name, u)
+}
+
+// AnnotationKeyResourceName is the key of the annotation that defines the
+// resource name.
+const AnnotationKeyResourceName = "fn-server.test/resource-name"
+
+// WithObservedResourcesYAML reads all objects from a multi-document YAML and
+// passes them with the observed state to the function.
+//
+// It uses the annotation [AnnotationKeyResourceName] to determine
+// the name of the resource.
+func WithObservedResourcesYAML(rawYAML []byte) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		uList, err := unmarshalObjectsYAML(rawYAML)
+		if err != nil {
+			panic(err.Error())
+		}
+		for _, u := range uList {
+			key, exists := u.GetAnnotations()[AnnotationKeyResourceName]
+			if !exists || key == "" {
+				panic("resource has no name annotation")
+			}
+			meta.RemoveAnnotations(u, AnnotationKeyResourceName)
+
+			str := mustObjectAsStruct(u)
+			tc.args.observedResources[key] = &fnapi.Resource{
+				Resource: str,
+			}
+		}
+	}
+}
+
+// WithObservedCompositeObject sets the observed composite to the given object.
+func WithObservedCompositeObject(o runtime.Object) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		str := mustObjectAsStruct(o)
+		tc.args.observedComposite = &fnapi.Resource{
+			Resource: str,
+		}
+	}
+}
+
+// WithObservedCompositeYAML reads an object from a single YAML document and
+// passes it as observed composite to the function.
+func WithObservedCompositeYAML(rawYaml []byte) TestFunctionOpt {
+	u := &unstructured.Unstructured{}
+	if err := yaml.Unmarshal(rawYaml, u); err != nil {
+		panic(err.Error())
+	}
+	return WithObservedCompositeObject(u)
+}
+
+// WithObservedCompositeJSON reads an object from a JSON document and
+// passes it as observed composite to the function.
+func WithObservedCompositeJSON(rawJSON []byte) TestFunctionOpt {
+	u := &unstructured.Unstructured{}
+	if err := json.Unmarshal(rawJSON, u); err != nil {
+		panic(err.Error())
+	}
+	return WithObservedCompositeObject(u)
+}

--- a/testing/opts_expect.go
+++ b/testing/opts_expect.go
@@ -1,0 +1,109 @@
+package testing
+
+import (
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	fnapi "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// ResourceModifier modifies a [fnapi.Resource].
+type ResourceModifier func(res *fnapi.Resource)
+
+// WithReady sets the ready state of an [fnapi.Resource].
+func WithReady(ready fnapi.Ready) ResourceModifier {
+	return func(res *fnapi.Resource) { res.Ready = ready }
+}
+
+// WithConnectionDetails sets the connection details of an [fnapi.Resource].
+func WithConnectionDetails(cd map[string][]byte) ResourceModifier {
+	return func(res *fnapi.Resource) { res.ConnectionDetails = cd }
+}
+
+// ExpectDesiredCompositeObject expects the given [runtime.Object] as desired
+// composite as result of the function.
+func ExpectDesiredCompositeObject(o runtime.Object, mods ...ResourceModifier) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		res := &fnapi.Resource{
+			Resource: mustObjectAsStruct(o),
+		}
+		for _, m := range mods {
+			m(res)
+		}
+		tc.want.desiredComposite = res
+	}
+}
+
+// ExpectDesiredCompositeYAML is the same as [ExpectDesiredCompositeObject] but
+// reads the object from a single YAML document.
+func ExpectDesiredCompositeYAML(rawYAML []byte, mods ...ResourceModifier) TestFunctionOpt {
+	return ExpectDesiredCompositeObject(mustUnstructuredFromYAML(rawYAML), mods...)
+}
+
+// ExpectDesiredCompositeJSON is the same as [ExpectDesiredCompositeObject] but
+// reads the object from a JSON document.
+func ExpectDesiredCompositeJSON(rawJSON []byte, mods ...ResourceModifier) TestFunctionOpt {
+	return ExpectDesiredCompositeObject(mustUnstructuredFromJSON(rawJSON), mods...)
+}
+
+// ExpectDesiredResourceObject adds an object to the expected outcome of a
+// function.
+func ExpectDesiredResourceObject(name string, o runtime.Object, mods ...ResourceModifier) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		res := &fnapi.Resource{
+			Resource: mustObjectAsStruct(o),
+		}
+		for _, m := range mods {
+			m(res)
+		}
+		tc.want.desiredResources[name] = res
+	}
+}
+
+// ExpectDesiredResourceYAML is the same as [ExpectDesiredResourceObject] but
+// reads the object from a single YAML document.
+func ExpectDesiredResourceYAML(name string, rawYAML []byte, mods ...ResourceModifier) TestFunctionOpt {
+	return ExpectDesiredResourceObject(name, mustUnstructuredFromYAML(rawYAML), mods...)
+}
+
+// ExpectDesiredResourceJSON is the same as [ExpectDesiredResourceObject] but
+// reads the object from a JSON document.
+func ExpectDesiredResourceJSON(name string, rawJSON []byte, mods ...ResourceModifier) TestFunctionOpt {
+	return ExpectDesiredResourceObject(name, mustUnstructuredFromJSON(rawJSON), mods...)
+}
+
+// ExpectedDesiredResourcesYAML reads all objects from a multi-document YAML and
+// expected them as desired resources from the function.
+//
+// It uses the annotation [AnnotationKeyResourceName] to determine
+// the name of the resource.
+func ExpectDesiredResourcesYAML(rawYAML []byte) TestFunctionOpt {
+	return func(tc *FunctionTest) {
+		uList, err := unmarshalObjectsYAML(rawYAML)
+		if err != nil {
+			panic(err.Error())
+		}
+		for _, u := range uList {
+			key, exists := u.GetAnnotations()[AnnotationKeyResourceName]
+			if !exists || key == "" {
+				panic("resource has no name annotation")
+			}
+			meta.RemoveAnnotations(u, AnnotationKeyResourceName)
+
+			str := mustObjectAsStruct(u)
+			tc.args.observedResources[key] = &fnapi.Resource{
+				Resource: str,
+				// TODO: Set connection details and ready state
+			}
+		}
+	}
+}
+
+// ExpectResults expects a list of [fnapi.Result] from a function.
+func ExpectResults(results []*fnapi.Result) TestFunctionOpt {
+	return func(tc *FunctionTest) { tc.want.results = results }
+}
+
+// ExpectError expects an error from a TestFunctionOpt.
+func ExpectError(err error) TestFunctionOpt {
+	return func(tc *FunctionTest) { tc.want.err = err }
+}

--- a/testing/run.go
+++ b/testing/run.go
@@ -1,0 +1,92 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	fnapi "github.com/crossplane/function-sdk-go/proto/v1beta1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/mistermx/crossplane-function-server/apis/v1alpha1"
+	"google.golang.org/protobuf/types/known/structpb"
+	evtv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	server "github.com/mistermx/crossplane-function-server"
+)
+
+type FunctionTest struct {
+	t  *testing.T
+	fn server.ServerFunction
+
+	// want function request
+	args struct {
+		input             evtv1.JSON
+		observedResources map[string]*fnapi.Resource
+		observedComposite *fnapi.Resource
+		context           *structpb.Struct
+	}
+	// want function response
+	want struct {
+		desiredResources map[string]*fnapi.Resource
+		desiredComposite *fnapi.Resource
+		err              error
+		results          []*fnapi.Result
+	}
+}
+
+type TestFunctionOpt func(tc *FunctionTest)
+
+func TestFunction(t *testing.T, fn server.ServerFunction, opts ...TestFunctionOpt) *FunctionTest {
+	tc := &FunctionTest{
+		t:  t,
+		fn: fn,
+	}
+	tc.args.observedResources = map[string]*fnapi.Resource{}
+	tc.args.context = &structpb.Struct{
+		Fields: map[string]*structpb.Value{},
+	}
+	tc.want.desiredResources = map[string]*fnapi.Resource{}
+	tc.want.results = []*fnapi.Result{}
+	for _, o := range opts {
+		o(tc)
+	}
+	return tc
+}
+
+func (t *FunctionTest) Run(ctx context.Context) {
+	req := server.RunServerFunctionRequest{
+		Req: &fnapi.RunFunctionRequest{
+			Observed: &fnapi.State{
+				Composite: t.args.observedComposite,
+				Resources: t.args.observedResources,
+			},
+			Context: t.args.context,
+		},
+		ServerInput: &v1alpha1.ServerInput{
+			Spec: v1alpha1.ServerInputSpec{
+				Input: t.args.input,
+			},
+		},
+	}
+	res := server.RunServerFunctionResponse{
+		DesiredComposed: map[string]*fnapi.Resource{},
+		DesiredContext:  &structpb.Struct{},
+	}
+
+	err := t.fn.Run(ctx, &req, &res)
+
+	// Compare test results with expected outcome and print any assert failure
+	// as a plain diff in the test results:
+
+	if diff := cmp.Diff(convertResourceToUnstructured(t.want.desiredComposite), convertResourceToUnstructured(res.DesiredComposite)); diff != "" {
+		t.t.Errorf("Composite: -want +got\n%s\n", diff)
+	}
+	if diff := cmp.Diff(convertResourcesMapToUnstructured(t.want.desiredResources), convertResourcesMapToUnstructured(res.DesiredComposed)); diff != "" {
+		t.t.Errorf("Resources: -want +got\n%s\n", diff)
+	}
+	if diff := cmp.Diff(convertResultsToMap(t.want.results), convertResultsToMap(res.Results)); diff != "" {
+		t.t.Errorf("Results: -want +got\n%s\n", diff)
+	}
+	if diff := cmp.Diff(t.want.err, err); diff != "" {
+		t.t.Errorf("Error: -want +got\n%s\n", diff)
+	}
+}


### PR DESCRIPTION
Add first draft of a framework for easy testing of server functions. The central idea is to input YAML files as input to functions and compare the expected output with `go-cmp`.