### PR TITLE
feat!: Return not-found error in req.GetCompose

### DIFF
--- a/error.go
+++ b/error.go
@@ -10,10 +10,14 @@ type errNotFound struct {
 	name string
 }
 
+func NewErrorNotFound(name string) error {
+	return &errNotFound{name: name}
+}
+
 func (e errNotFound) Error() string {
 	return fmt.Sprintf("not found: %s", e.name)
 }
 
-func IsNotFoundError(err error) bool {
+func IsErrorNotFound(err error) bool {
 	return errors.As(err, &errNotFound{})
 }

--- a/error_test.go
+++ b/error_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestIsNotFoundError(t *testing.T) {
+func TestIsErrorNotFound(t *testing.T) {
 	type args struct {
 		err error
 	}
@@ -36,7 +36,7 @@ func TestIsNotFoundError(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			res := IsNotFoundError(tc.err)
+			res := IsErrorNotFound(tc.err)
 			if res != tc.want.isNotFound {
 				t.Errorf("Expected %v but got %v", tc.want.isNotFound, res)
 			}

--- a/server.go
+++ b/server.go
@@ -80,7 +80,7 @@ func (r *RunServerFunctionRequest) GetComposed(name string, target runtime.Objec
 	resources := r.Req.GetObserved().GetResources()
 	res, exists := resources[name]
 	if !exists {
-		return nil
+		return NewErrorNotFound(name)
 	}
 	return resource.AsObject(res.GetResource(), target)
 }
@@ -146,7 +146,7 @@ func (r *RunServerFunctionResponse) SetComposed(name string, o runtime.Object, m
 func (r *RunServerFunctionResponse) GetComposed(name string, target runtime.Object) error {
 	state, exists := r.DesiredComposed[name]
 	if !exists {
-		return errNotFound{name: name}
+		return NewErrorNotFound(name)
 	}
 	return resource.AsObject(state.Resource, target)
 }

--- a/server_function.go
+++ b/server_function.go
@@ -33,8 +33,8 @@ type ServerFunctionRequest interface {
 	// GetComposed copies the current state of the composed resource identified
 	// by the given name.
 	//
-	// If a no composed resource with the given name exists, target remains
-	// unchanged.
+	// If a no composed resource with the given name exists, it returns a
+	// not-found error that be checked with [IsErrorNotFound]
 	GetComposed(name string, target runtime.Object) error
 }
 


### PR DESCRIPTION
Add `NewErrorNotFound` and rename `IsNotFoundError` to `IsErrorNotFound`.