### PR TITLE
fix(error): Incorrect IsErrorNotFound behaviour

### DIFF
--- a/error.go
+++ b/error.go
@@ -11,7 +11,7 @@ type errNotFound struct {
 }
 
 func NewErrorNotFound(name string) error {
-	return &errNotFound{name: name}
+	return errNotFound{name: name}
 }
 
 func (e errNotFound) Error() string {

--- a/error_test.go
+++ b/error_test.go
@@ -19,7 +19,15 @@ func TestIsErrorNotFound(t *testing.T) {
 	}{
 		"ExpectTrue": {
 			args: args{
-				err: errNotFound{},
+				err: NewErrorNotFound("not-found"),
+			},
+			want: want{
+				isNotFound: true,
+			},
+		},
+		"ExpectWrappedTrue": {
+			args: args{
+				err: errors.Wrap(NewErrorNotFound("not-found"), "wrap"),
 			},
 			want: want{
 				isNotFound: true,


### PR DESCRIPTION
Return value instead of pointer in `NewErrorNotFound` that caused `IsErrorNotFound` to return false when expecting true.